### PR TITLE
add missing password policy field

### DIFF
--- a/src/Keycloak.Net/Models/RealmsAdmin/Realm.cs
+++ b/src/Keycloak.Net/Models/RealmsAdmin/Realm.cs
@@ -134,5 +134,7 @@ namespace Keycloak.Net.Models.RealmsAdmin
         public Attributes Attributes { get; set; }
         [JsonProperty("userManagedAccessAllowed")]
         public bool? UserManagedAccessAllowed { get; set; }
+        [JsonProperty("passwordPolicy")]
+        public string PasswordPolicy{ get; set; }
     }
 }


### PR DESCRIPTION
This is a minor change to support 'password policy' retrieval on realm data fetch.