### PR TITLE
SetUserPasswordAsync which sets non-temporary pwd

### DIFF
--- a/src/Keycloak.Net/Users/KeycloakClient.cs
+++ b/src/Keycloak.Net/Users/KeycloakClient.cs
@@ -210,6 +210,14 @@ namespace Keycloak.Net
                 .ConfigureAwait(false);
             return response.IsSuccessStatusCode;
         }
+        public async Task<bool> SetUserPasswordAsync(string realm, string userId, string password)
+        {
+            var response = await GetBaseUrl(realm)
+                .AppendPathSegment($"/admin/realms/{realm}/users/{userId}/reset-password")
+                .PutJsonAsync(new { type = "password", value = password, temporary = false })
+                .ConfigureAwait(false);
+            return response.IsSuccessStatusCode;
+        }
 
         public async Task<bool> VerifyUserEmailAddressAsync(string realm, string userId, string clientId = null, string redirectUri = null)
         {


### PR DESCRIPTION
SetUserPasswordAsync which sets non-temporary pwd, in order to provide real password reset, instead of temporary as it implemented in ResetUserPasswordAsync which sets temporary pwd